### PR TITLE
[TASK-202] Add template-driven encounter generation

### DIFF
--- a/game/README.md
+++ b/game/README.md
@@ -15,6 +15,7 @@
 ## Run tests (headless)
 ```bash
 godot4 --headless --path game -s res://scripts/tests/replay_test.gd
+godot4 --headless --path game -s res://scripts/tests/encounter_templates_test.gd
 godot4 --headless --path game -s res://scripts/tests/enemy_state_test.gd
 godot4 --headless --path game -s res://scripts/tests/progression_integrity_test.gd
 godot4 --headless --path game -s res://scripts/tests/reward_scaling_test.gd

--- a/game/autoload/data_store.gd
+++ b/game/autoload/data_store.gd
@@ -4,6 +4,7 @@ class_name DataStore
 var rings: Dictionary = {}
 var enemies: Dictionary = {}
 var weapons: Dictionary = {}
+var encounter_templates: Dictionary = {}
 
 func _ready() -> void:
 	load_data()
@@ -12,6 +13,7 @@ func load_data() -> void:
 	rings = _load_json("res://data/rings.json")
 	enemies = _load_json("res://data/enemies.json")
 	weapons = _load_json("res://data/weapons.json")
+	encounter_templates = _load_json("res://data/encounter_templates.json")
 
 func _load_json(path: String) -> Dictionary:
 	if not FileAccess.file_exists(path):

--- a/game/data/encounter_templates.json
+++ b/game/data/encounter_templates.json
@@ -1,0 +1,29 @@
+{
+  "templates": [
+    {
+      "id": "inner_patrol_a",
+      "ring": "inner",
+      "enemy_ids": ["scavenger_grunt", "shieldbearer"]
+    },
+    {
+      "id": "inner_swarm_a",
+      "ring": "inner",
+      "enemy_ids": ["scavenger_grunt", "scavenger_grunt", "scavenger_grunt"]
+    },
+    {
+      "id": "inner_ranged_mix",
+      "ring": "inner",
+      "enemy_ids": ["scavenger_grunt", "ridge_archer"]
+    },
+    {
+      "id": "mid_patrol_a",
+      "ring": "mid",
+      "enemy_ids": ["ash_flanker", "ridge_archer", "shieldbearer"]
+    },
+    {
+      "id": "outer_elite_a",
+      "ring": "outer",
+      "enemy_ids": ["warden_hunter", "rift_caster"]
+    }
+  ]
+}

--- a/game/scripts/systems/ring_director.gd
+++ b/game/scripts/systems/ring_director.gd
@@ -2,7 +2,16 @@ extends RefCounted
 class_name RingDirector
 
 # Deterministic ring encounter selection based on seed and ring index.
-func generate_encounter(seed: int, ring_id: String, enemies_data: Dictionary) -> Dictionary:
+func generate_encounter(
+	seed: int,
+	ring_id: String,
+	enemies_data: Dictionary,
+	templates_data: Dictionary = {}
+) -> Dictionary:
+	var template_encounter := _generate_template_encounter(seed, ring_id, enemies_data, templates_data)
+	if not template_encounter.is_empty():
+		return template_encounter
+
 	var candidates: Array = []
 	for enemy in enemies_data.get("enemies", []):
 		if ring_id in enemy.get("rings", []):
@@ -26,3 +35,45 @@ func generate_encounter(seed: int, ring_id: String, enemies_data: Dictionary) ->
 
 func _combine_seed(seed: int, ring_id: String) -> int:
 	return int(seed + ring_id.hash())
+
+func _generate_template_encounter(
+	seed: int,
+	ring_id: String,
+	enemies_data: Dictionary,
+	templates_data: Dictionary
+) -> Dictionary:
+	var templates: Array = templates_data.get("templates", [])
+	if templates.is_empty():
+		return {}
+
+	var ring_templates: Array = []
+	for template in templates:
+		if str(template.get("ring", "")) == ring_id:
+			ring_templates.append(template)
+	if ring_templates.is_empty():
+		return {}
+
+	var by_id: Dictionary = {}
+	for enemy in enemies_data.get("enemies", []):
+		by_id[str(enemy.get("id", ""))] = enemy
+
+	var rng := RandomNumberGenerator.new()
+	rng.seed = _combine_seed(seed, ring_id)
+	var template := ring_templates[rng.randi_range(0, ring_templates.size() - 1)]
+
+	var selected: Array = []
+	for enemy_id in template.get("enemy_ids", []):
+		var key := str(enemy_id)
+		if by_id.has(key):
+			selected.append(by_id[key])
+
+	if selected.is_empty():
+		return {}
+
+	return {
+		"ring": ring_id,
+		"seed": seed,
+		"template_id": str(template.get("id", "")),
+		"enemy_count": selected.size(),
+		"enemies": selected,
+	}

--- a/game/scripts/tests/encounter_templates_test.gd
+++ b/game/scripts/tests/encounter_templates_test.gd
@@ -1,0 +1,39 @@
+extends SceneTree
+
+func _initialize() -> void:
+	var enemies := _load_json("res://data/enemies.json")
+	var templates := _load_json("res://data/encounter_templates.json")
+	if enemies.is_empty() or templates.is_empty():
+		_fail("Data files failed to parse")
+		return
+
+	var by_id: Dictionary = {}
+	for enemy in enemies.get("enemies", []):
+		by_id[str(enemy.get("id", ""))] = true
+
+	var ring_counts: Dictionary = {}
+	for template in templates.get("templates", []):
+		var ring_id := str(template.get("ring", ""))
+		ring_counts[ring_id] = int(ring_counts.get(ring_id, 0)) + 1
+		for enemy_id in template.get("enemy_ids", []):
+			if not by_id.has(str(enemy_id)):
+				_fail("Template references unknown enemy id: %s" % str(enemy_id))
+				return
+
+	if int(ring_counts.get("inner", 0)) == 0:
+		_fail("Missing inner ring templates")
+		return
+
+	print("PASS: encounter templates test")
+	quit(0)
+
+func _load_json(path: String) -> Dictionary:
+	var raw := FileAccess.get_file_as_string(path)
+	var parsed: Variant = JSON.parse_string(raw)
+	if typeof(parsed) != TYPE_DICTIONARY:
+		return {}
+	return parsed
+
+func _fail(message: String) -> void:
+	printerr("FAIL: %s" % message)
+	quit(1)

--- a/game/scripts/tests/replay_test.gd
+++ b/game/scripts/tests/replay_test.gd
@@ -3,21 +3,33 @@ extends SceneTree
 const RingDirector = preload("res://scripts/systems/ring_director.gd")
 
 func _initialize() -> void:
-	var data_text := FileAccess.get_file_as_string("res://data/enemies.json")
-	var parsed: Variant = JSON.parse_string(data_text)
-	if typeof(parsed) != TYPE_DICTIONARY:
+	var enemies := _load_json("res://data/enemies.json")
+	var templates := _load_json("res://data/encounter_templates.json")
+	if enemies.is_empty() or templates.is_empty():
 		printerr("FAIL: enemies.json parse")
 		quit(1)
 		return
 
 	var director := RingDirector.new()
 	var seed := 424242
-	var a := director.generate_encounter(seed, "inner", parsed)
-	var b := director.generate_encounter(seed, "inner", parsed)
+	var a := director.generate_encounter(seed, "inner", enemies, templates)
+	var b := director.generate_encounter(seed, "inner", enemies, templates)
 	if JSON.stringify(a) != JSON.stringify(b):
 		printerr("FAIL: encounter generation is not deterministic")
 		quit(1)
 		return
 
+	if str(a.get("template_id", "")) == "":
+		printerr("FAIL: encounter template id missing")
+		quit(1)
+		return
+
 	print("PASS: deterministic replay seed test")
 	quit(0)
+
+func _load_json(path: String) -> Dictionary:
+	var raw := FileAccess.get_file_as_string(path)
+	var parsed: Variant = JSON.parse_string(raw)
+	if typeof(parsed) != TYPE_DICTIONARY:
+		return {}
+	return parsed

--- a/scripts/ci/headless_tests.sh
+++ b/scripts/ci/headless_tests.sh
@@ -5,12 +5,14 @@ echo "[headless-tests] Starting"
 
 if command -v godot4 >/dev/null 2>&1; then
   godot4 --headless --path game -s res://scripts/tests/replay_test.gd
+  godot4 --headless --path game -s res://scripts/tests/encounter_templates_test.gd
   godot4 --headless --path game -s res://scripts/tests/enemy_state_test.gd
   godot4 --headless --path game -s res://scripts/tests/progression_integrity_test.gd
   godot4 --headless --path game -s res://scripts/tests/reward_scaling_test.gd
 else
   echo "godot4 not found in runner. Performing structural checks only."
   test -f game/scripts/tests/replay_test.gd
+  test -f game/scripts/tests/encounter_templates_test.gd
   test -f game/scripts/tests/enemy_state_test.gd
   test -f game/scripts/tests/progression_integrity_test.gd
   test -f game/scripts/tests/reward_scaling_test.gd


### PR DESCRIPTION
## Task Link
- Linked issue: Closes #12
- Task ID: TASK-202

## Scope Declaration
- Branch name follows: `codex/<task-id>-<short-slug>`
- This PR only implements one task issue
- Allowed files respected: Yes

## Acceptance Criteria
- [x] Template data loads successfully
- [x] RingDirector selects from templates deterministically
- [x] Existing replay test remains stable

## Required Checks
- [x] `headless-tests`
- [x] `lint`
- [x] `smoke-scene`
- [x] `task-specific-tests`

## Test Evidence
- `scripts/ci/lint.sh`
- `scripts/ci/headless_tests.sh`
- `scripts/ci/smoke_scene.sh`
- `scripts/ci/task_specific_tests.sh`

## Verifier Section (Required)
- Verifier requested: Pending CI + review
- Verifier findings addressed: N/A

## Risk and Rollback
- Risk level: medium
- Rollback plan: Revert this PR

## Documentation and ADR
- [x] No interface/contract breaking changes
- [x] Updated docs (`game/README.md`)
- [ ] Updated ADR (not required)
