### PR TITLE
[TASK-201] Add Sanctuary loadout selector

### DIFF
--- a/game/scenes/ui/flow_ui.tscn
+++ b/game/scenes/ui/flow_ui.tscn
@@ -17,6 +17,14 @@ text = "Sanctuary Prep"
 [node name="PrepStatus" type="Label" parent="PrepScreen"]
 text = ""
 
+[node name="LoadoutLabel" type="Label" parent="PrepScreen"]
+text = "Weapon Loadout"
+
+[node name="LoadoutSelect" type="OptionButton" parent="PrepScreen"]
+
+[node name="LoadoutSummary" type="Label" parent="PrepScreen"]
+text = ""
+
 [node name="StartRunButton" type="Button" parent="PrepScreen"]
 text = "Enter Ring 1"
 
@@ -33,6 +41,9 @@ text = "Expedition"
 [node name="RunStatus" type="Label" parent="RunScreen"]
 text = ""
 
+[node name="RunLoadout" type="Label" parent="RunScreen"]
+text = ""
+
 [node name="ResolveEncounterButton" type="Button" parent="RunScreen"]
 text = "Resolve Encounter"
 
@@ -43,6 +54,7 @@ text = "Extract to Sanctuary"
 text = "Simulate Death"
 
 [connection signal="pressed" from="PrepScreen/StartRunButton" to="." method="_on_start_run_button_pressed"]
+[connection signal="item_selected" from="PrepScreen/LoadoutSelect" to="." method="_on_loadout_select_item_selected"]
 [connection signal="pressed" from="RunScreen/ResolveEncounterButton" to="." method="_on_resolve_encounter_button_pressed"]
 [connection signal="pressed" from="RunScreen/ExtractButton" to="." method="_on_extract_button_pressed"]
 [connection signal="pressed" from="RunScreen/DieButton" to="." method="_on_die_button_pressed"]

--- a/game/scripts/main.gd
+++ b/game/scripts/main.gd
@@ -8,11 +8,13 @@ const RewardSystem = preload("res://scripts/systems/reward_system.gd")
 var ring_director := RingDirector.new()
 var reward_system := RewardSystem.new()
 var active_encounter: Dictionary = {}
+var selected_weapon_id: String = "blade_iron"
 
 func _ready() -> void:
 	print("The Long Walk MVP Slice 1 booted")
 	_connect_ui()
 	_connect_state()
+	_initialize_loadouts()
 	flow_ui.on_idle_ready()
 
 func _connect_ui() -> void:
@@ -20,6 +22,7 @@ func _connect_ui() -> void:
 	flow_ui.resolve_encounter_pressed.connect(_on_resolve_encounter_pressed)
 	flow_ui.extract_pressed.connect(_on_extract_pressed)
 	flow_ui.die_pressed.connect(_on_die_pressed)
+	flow_ui.loadout_selected.connect(_on_loadout_selected)
 
 func _connect_state() -> void:
 	GameState.run_started.connect(flow_ui.on_run_started)
@@ -31,6 +34,7 @@ func _on_start_run_pressed() -> void:
 	var seed := Time.get_unix_time_from_system()
 	GameState.start_run(int(seed), "inner")
 	active_encounter = ring_director.generate_encounter(int(seed), "inner", DataStore.enemies)
+	flow_ui.set_current_loadout(selected_weapon_id)
 
 func _on_resolve_encounter_pressed() -> void:
 	if GameState.current_ring == "sanctuary":
@@ -58,3 +62,14 @@ func _on_die_pressed() -> void:
 
 func _on_player_died() -> void:
 	flow_ui.on_died(GameState.unbanked_xp, GameState.unbanked_loot)
+
+func _initialize_loadouts() -> void:
+	var weapons := DataStore.weapons.get("weapons", [])
+	if weapons.size() > 0:
+		selected_weapon_id = str(weapons[0].get("id", selected_weapon_id))
+	flow_ui.set_available_loadouts(weapons)
+	flow_ui.set_current_loadout(selected_weapon_id)
+
+func _on_loadout_selected(weapon_id: String) -> void:
+	selected_weapon_id = weapon_id
+	flow_ui.set_current_loadout(selected_weapon_id)

--- a/game/scripts/ui/flow_ui.gd
+++ b/game/scripts/ui/flow_ui.gd
@@ -5,11 +5,15 @@ signal start_run_pressed
 signal resolve_encounter_pressed
 signal extract_pressed
 signal die_pressed
+signal loadout_selected(weapon_id: String)
 
 @onready var prep_screen: VBoxContainer = $PrepScreen
 @onready var run_screen: VBoxContainer = $RunScreen
 @onready var prep_status: Label = $PrepScreen/PrepStatus
+@onready var loadout_select: OptionButton = $PrepScreen/LoadoutSelect
+@onready var loadout_summary: Label = $PrepScreen/LoadoutSummary
 @onready var run_status: Label = $RunScreen/RunStatus
+@onready var run_loadout: Label = $RunScreen/RunLoadout
 
 func _ready() -> void:
 	_show_prep()
@@ -26,6 +30,10 @@ func _on_extract_button_pressed() -> void:
 func _on_die_button_pressed() -> void:
 	die_pressed.emit()
 
+func _on_loadout_select_item_selected(index: int) -> void:
+	var weapon_id := loadout_select.get_item_metadata(index)
+	loadout_selected.emit(str(weapon_id))
+
 func _show_prep() -> void:
 	prep_screen.visible = true
 	run_screen.visible = false
@@ -37,6 +45,20 @@ func _show_run() -> void:
 func on_run_started(seed: int) -> void:
 	_show_run()
 	run_status.text = "Run active (seed %d)" % seed
+
+func set_available_loadouts(weapons: Array) -> void:
+	loadout_select.clear()
+	for weapon in weapons:
+		var weapon_id := str(weapon.get("id", ""))
+		loadout_select.add_item(weapon_id)
+		loadout_select.set_item_metadata(loadout_select.get_item_count() - 1, weapon_id)
+	if loadout_select.get_item_count() > 0:
+		loadout_select.select(0)
+		_on_loadout_select_item_selected(0)
+
+func set_current_loadout(weapon_id: String) -> void:
+	loadout_summary.text = "Selected loadout: %s" % weapon_id
+	run_loadout.text = "Loadout: %s" % weapon_id
 
 func on_encounter_resolved(xp_gain: int, loot_gain: int) -> void:
 	run_status.text = "Encounter won: +%d XP, +%d Loot" % [xp_gain, loot_gain]


### PR DESCRIPTION
## Task Link
- Linked issue: Closes #11
- Task ID: TASK-201

## Scope Declaration
- Branch name follows: `codex/<task-id>-<short-slug>`
- This PR only implements one task issue
- Allowed files respected: Yes

## Acceptance Criteria
- [x] Selected weapon persists through run start
- [x] Current loadout visible in prep and run screens
- [x] No regression in extract flow

## Required Checks
- [x] `headless-tests`
- [x] `lint`
- [x] `smoke-scene`
- [x] `task-specific-tests`

## Test Evidence
- `scripts/ci/lint.sh`
- `scripts/ci/headless_tests.sh`
- `scripts/ci/smoke_scene.sh`
- `scripts/ci/task_specific_tests.sh`

## Verifier Section (Required)
- Verifier requested: Pending CI + review
- Verifier findings addressed: N/A

## Risk and Rollback
- Risk level: medium
- Rollback plan: Revert this PR

## Documentation and ADR
- [x] No interface/contract changes
- [ ] Updated docs
- [ ] Updated ADR (not required)